### PR TITLE
Debian Stretch support and apt optimizations

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -2,8 +2,9 @@
   include_vars: "vars/{{ ansible_distribution_release }}.yml"
 
 - name: app {{djangoapp_name}} | install app python and system dependencies
-  apt: name={{item}} state=present
-  with_items:
+  apt: name={{ items|join(",") }} state=present
+  vars:
+    items:
     - python
     - python-dev
     - python3

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -1,3 +1,5 @@
+- name: app {{djangoapp_name}} | include release-specific vars
+  include_vars: "vars/{{ ansible_distribution_release }}.yml"
 
 - name: app {{djangoapp_name}} | install app python and system dependencies
   apt: name={{item}} state=present
@@ -43,8 +45,8 @@
     - libffi6
     - libpango1.0-dev
     - libpq-dev
-    - libmysqlclient-dev
     - mysql-client
+    - "{{ libmysql_client_dev }}"
 
 - name: app {{djangoapp_name}} | create user group
   group: name={{djangoapp_user}} state=present

--- a/vars/jessie.yml
+++ b/vars/jessie.yml
@@ -1,0 +1,1 @@
+libmysql_client_dev: libmysqlclient-dev

--- a/vars/stretch.yml
+++ b/vars/stretch.yml
@@ -1,0 +1,1 @@
+libmysql_client_dev: libmariadbclient-dev-compat


### PR DESCRIPTION
Two small changes:

- Package `libmysqlclient-dev` is no longer present in Stretch, so I've added a check
- Apt was installing every item on a long list in a separate transaction, which was very inefficient - switched to using a single transaction
