### PR TITLE
Misc fixes

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -10,3 +10,5 @@ djangoapp_venv: "{{djangoapp_home}}/venv"
 djangoapp_src: "{{djangoapp_home}}/src"
 
 djangoapp_uwsgiproc: 10
+
+djangoapp_newrelic: ~

--- a/templates/uwsgi.ini.j2
+++ b/templates/uwsgi.ini.j2
@@ -1,7 +1,7 @@
 [uwsgi]
 
 master          = true
-processes       = {{djangoapp_uwsgiproc|default:10}}
+processes       = {{djangoapp_uwsgiproc}}
 chmod_socket    = 664
 socket          = /tmp/{{djangoapp_name}}.sock
 touch-reload    = /tmp/{{djangoapp_name}}.reload

--- a/templates/uwsgi.ini.j2
+++ b/templates/uwsgi.ini.j2
@@ -28,5 +28,5 @@ env             = NEWRELIC={{djangoapp_home}}/newrelic.ini
 
 {% if djangoapp_celery_enabled %}
 attach-daemon = {{djangoapp_venv}}/bin/celery worker -A {{djangoapp_name}} -E -B -S django
-attach-daemon = {{djangoapp_venv}}/bin/celery -A burg flower
+attach-daemon = {{djangoapp_venv}}/bin/celery -A {{djangoapp_name}} flower
 {% endif %}


### PR DESCRIPTION
- `djangoapp_newrelic` was undefined in defaults
- `djangoapp_uwsgiproc` is already default at 10, also Django-style argument passing syntax was used in place of Jinja's
- a particular value for `djangoapp_name` was hardcoded in uwsgi.ini.j2
