### PR TITLE
Env overrides

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -10,3 +10,5 @@ djangoapp_venv: "{{djangoapp_home}}/venv"
 djangoapp_src: "{{djangoapp_home}}/src"
 
 djangoapp_uwsgiproc: 10
+
+djangoapp_env_template: templates/env.j2

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -12,3 +12,5 @@ djangoapp_src: "{{djangoapp_home}}/src"
 djangoapp_uwsgiproc: 10
 
 djangoapp_env_template: templates/env.j2
+djangoapp_env_force:    no
+

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -64,7 +64,11 @@
   tags: ['update']
 
 - name: app {{djangoapp_name}} | create production .env file
-  template: src=templates/env.j2  dest="{{djangoapp_src}}/.env" mode=0640 force=no
+  template:
+    src:   "{{ djangoapp_env_template }}"
+    dest:  "{{ djangoapp_src }}/.env"
+    mode:  "0640"
+    force: no
   become_user: "{{ djangoapp_user }}"
   tags: ['update']
 

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -68,7 +68,7 @@
     src:   "{{ djangoapp_env_template }}"
     dest:  "{{ djangoapp_src }}/.env"
     mode:  "0640"
-    force: no
+    force: "{{ djangoapp_env_force }}"
   become_user: "{{ djangoapp_user }}"
   tags: ['update']
 


### PR DESCRIPTION
- Allow specifying a custom template for the .env file
- Allow force-updating it

It makes it possible for Ansible to become the source of truth about the environment for the project, but leaves previous behavior as default.
